### PR TITLE
Virtual IRQs (or Retiring Kernel Semaphores)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "kernel/nova"]
 	path = kernel/nova
-	url = https://github.com/TUD-OS/NOVA.git
+	url = https://github.com/blitz/NOVA.git

--- a/nre/apps/mutex-deadlock/SConscript
+++ b/nre/apps/mutex-deadlock/SConscript
@@ -1,0 +1,6 @@
+# -*- Mode: Python -*-
+
+Import('env')
+
+env.NREProgram(env, 'mutex-deadlock', Glob('*.cc'))
+

--- a/nre/apps/mutex-torture/SConscript
+++ b/nre/apps/mutex-torture/SConscript
@@ -1,0 +1,6 @@
+# -*- Mode: Python -*-
+
+Import('env')
+
+env.NREProgram(env, 'mutex-torture', Glob('*.cc'))
+

--- a/nre/apps/mutex-torture/mutex.cc
+++ b/nre/apps/mutex-torture/mutex.cc
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2012, Julian Stecklina <jsteckli@os.inf.tu-dresden.de>
+ * Economic rights: Technische Universitaet Dresden (Germany)
+ *
+ * This file is part of NRE (NOVA runtime environment).
+ *
+ * NRE is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * NRE is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License version 2 for more details.
+ */
+
+#include <kobj/GlobalThread.h>
+#include <kobj/Vi.h>
+#include <kobj/Mutex.h>
+#include <ipc/Connection.h>
+#include <services/Timer.h>
+#include <util/Clock.h>
+#include <services/Console.h>
+#include <CPU.h>
+
+using namespace nre;
+
+static Connection timercon("timer");
+static Connection conscon("console");
+static ConsoleSession cons(conscon, 0, String("vitest"));
+
+static Mutex     mutex;
+static volatile unsigned long critical_int;
+static volatile unsigned long acquire_count;
+
+
+static unsigned long per_cpu[Hip::MAX_CPUS];
+
+static void mutex_torture(void *)
+{
+    unsigned long acq;
+    cpu_t         id = CPU::current().log_id();
+    
+    while (true) {
+        mutex.acquire();
+        acq = ++ acquire_count;
+        per_cpu[id] ++;
+        
+        assert(critical_int == 0);
+
+        critical_int = id;
+
+        assert(critical_int == id);
+        
+        critical_int = 0;
+        assert(critical_int == 0);
+
+        assert(acq == acquire_count);
+        mutex.release();
+    }
+}
+
+int main()
+{
+    auto &serial = Serial::get();
+
+    serial.writef("Mutex stress test up.\n");
+    for (CPU::iterator it = CPU::begin(); it != CPU::end(); ++it) {
+        serial.writef("Starting thread on CPU%u.\n", it->log_id());
+
+        GlobalThread *gt = GlobalThread::create(mutex_torture, it->log_id(), "mutex-torture");
+        gt->start();
+    }
+
+    TimerSession timer(timercon);
+    Clock clock(1000);
+
+    unsigned long last_acq = 0;
+    while (true) {
+        timevalue_t   next = clock.source_time(1000);
+        unsigned long cur_acq = acquire_count;
+        
+        serial.writef("acq %016lx per-sec %08lx critical_int %lx\n",
+                      cur_acq, cur_acq - last_acq,  critical_int);
+
+        unsigned i = 0;
+        for (CPU::iterator it = CPU::begin(); it != CPU::end(); ++it, i++) {
+            serial.writef("%16lx ", per_cpu[i]);
+        }
+        serial.writef("\n");
+
+        last_acq = cur_acq;
+
+        // wait a second
+        timer.wait_until(next);
+    }
+
+    return 0;
+}

--- a/nre/apps/vitest/SConscript
+++ b/nre/apps/vitest/SConscript
@@ -1,0 +1,5 @@
+# -*- Mode: Python -*-
+
+Import('env')
+
+env.NREProgram(env, 'vitest', Glob('*.cc'))

--- a/nre/apps/vitest/vitest.cc
+++ b/nre/apps/vitest/vitest.cc
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2012, Julian Stecklina <jsteckli@os.inf.tu-dresden.de>
+ * Economic rights: Technische Universitaet Dresden (Germany)
+ *
+ * This file is part of NRE (NOVA runtime environment).
+ *
+ * NRE is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * NRE is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License version 2 for more details.
+ */
+
+#include <kobj/GlobalThread.h>
+#include <kobj/Vi.h>
+#include <ipc/Connection.h>
+#include <services/Console.h>
+#include <CPU.h>
+
+#include <util/Date.h>
+#include <Exception.h>
+
+using namespace nre;
+
+
+static Connection conscon("console");
+static ConsoleSession cons(conscon, 0, String("vitest"));
+
+PORTAL static void recall_handler(capsel_t)
+{
+    // May deadlock...
+    Serial::get().writef("CPU%u: Recall!\n", CPU::current().log_id());
+}
+
+static void wait_and_print(void *)
+{
+    auto &serial = Serial::get();
+    serial.writef("CPU%u: Waiting for events.\n", CPU::current().log_id());
+    while (true) {
+        Vi::block();
+
+        serial.writef("CPU%u: Events: %lx.\n", CPU::current().log_id(),
+                      Thread::current()->fetch_events());
+    }
+}
+
+int main()
+{
+    auto &serial = Serial::get();
+
+    serial.writef("Virtual IRQ test up.\n");
+
+    Vi *irqs[CPU::count()];
+    for (CPU::iterator it = CPU::begin(); it != CPU::end(); ++it) {
+        ScopedCapSels c;
+        serial.writef("Starting thread on CPU%u.\n", it->log_id());
+
+        LocalThread  *lt = LocalThread ::create(it->log_id());
+        Pt           *pt = new Pt(lt, Hip::get().service_caps() * it->log_id() + CapSelSpace::Caps::EV_RECALL,
+                                  recall_handler);
+        GlobalThread *gt = GlobalThread::create(wait_and_print, it->log_id(), "vitest-thread");
+        serial.writef("Creating Virtual IRQ for CPU%u (cap %u).\n", it->log_id(), c.get());
+        irqs[it->log_id()] = new Vi(gt, gt, c.get(), 1 << it->log_id());
+        c.release();
+        gt->start();
+    }
+
+    while (true) {
+        auto k = cons.receive();
+        if (not (k.flags & Keyboard::RELEASE)) continue;
+        switch (k.character) {
+            case 'q': return 0;
+            case '0' ... '9': {
+                cpu_t c = k.character - '0';
+                if (c >= CPU::count()) break;
+
+                serial.writef("Triggering CPU%u.\n", c);
+                irqs[c]->trigger();
+                break;
+            }
+        }
+    }
+
+    serial.writef("Virtual IRQ finished successfully.\n");
+    return 0;
+}

--- a/nre/boot/mutex-deadlock
+++ b/nre/boot/mutex-deadlock
@@ -1,0 +1,15 @@
+#!tools/novaboot
+# -*-sh-*-
+QEMU_FLAGS=-m 256 -smp 4
+HYPERVISOR_PARAMS=spinner serial
+bin/apps/root
+bin/apps/acpi provides=acpi
+bin/apps/keyboard provides=keyboard
+bin/apps/reboot provides=reboot
+bin/apps/pcicfg provides=pcicfg
+bin/apps/timer provides=timer
+bin/apps/console provides=console
+bin/apps/mutex-deadlock
+bin/apps/sysinfo
+bin/apps/cycleburner
+

--- a/nre/boot/mutex-torture
+++ b/nre/boot/mutex-torture
@@ -1,0 +1,15 @@
+#!tools/novaboot
+# -*-sh-*-
+QEMU_FLAGS=-m 256 -smp 4
+HYPERVISOR_PARAMS=spinner serial
+bin/apps/root
+bin/apps/acpi provides=acpi
+bin/apps/keyboard provides=keyboard
+bin/apps/reboot provides=reboot
+bin/apps/pcicfg provides=pcicfg
+bin/apps/timer provides=timer
+bin/apps/console provides=console
+bin/apps/mutex-torture
+bin/apps/sysinfo
+bin/apps/cycleburner
+

--- a/nre/boot/vitest
+++ b/nre/boot/vitest
@@ -1,0 +1,13 @@
+#!tools/novaboot
+# -*-sh-*-
+QEMU_FLAGS=-m 256 -smp 4
+HYPERVISOR_PARAMS=spinner serial
+bin/apps/root
+bin/apps/acpi provides=acpi
+bin/apps/keyboard provides=keyboard
+bin/apps/reboot provides=reboot
+bin/apps/pcicfg provides=pcicfg
+bin/apps/timer provides=timer
+bin/apps/console provides=console
+bin/apps/vitest
+

--- a/nre/include/Syscalls.h
+++ b/nre/include/Syscalls.h
@@ -44,6 +44,8 @@ class Syscalls {
         SM_CTRL,
         ASSIGN_PCI,
         ASSIGN_GSI,
+        CREATE_VI,
+        VI_CTRL,
         CREATE_EC_GLOBAL = CREATE_EC | FLAG0,
         REVOKE_MYSELF  = REVOKE | FLAG0,
     };
@@ -75,6 +77,14 @@ public:
      */
     enum ScOp {
         GETTIME = 0
+    };
+
+    /**
+     * Vi operations
+     */
+    enum ViOp {
+        BLOCK   = 0,
+        TRIGGER = FLAG0,
     };
 
     /**
@@ -240,6 +250,32 @@ public:
         SyscallABI::syscall(LOOKUP, crd.value(), 0, 0, 0, out1, out2);
         return Crd(out1);
     }
+
+    /**
+     * Creates a new Vi (Virtual IRQ).
+     *
+     * @param vi    the capability selector to use for the Vi
+     * @param ec    the ec that handles this Vi
+     * @param evt   the event bitmask
+     * @param dstpd the Pd in which the Pd should be created
+     * @throws SyscallException if the system-call failed (result != E_SUCCESS)
+     */
+    static void create_vi(capsel_t vi, capsel_t ec_handler, capsel_t ec_recall, uint32_t evt, capsel_t dstpd) {
+        SyscallABI::syscall(vi << 8 | CREATE_VI, dstpd, ec_handler, ec_recall, evt);
+    }
+
+
+    /**
+     * Triggers a Vi or blocks the thread.
+     *
+     * @param vi the capability selector (may be 0 for BLOCK)
+     * @param op the requested operation
+     * @throws SyscallException if the system-call failed (result != E_SUCCESS)
+     */
+    static void vi_ctrl(capsel_t vi, ViOp op) {
+        SyscallABI::syscall(vi << 8 | VI_CTRL | op);
+    }
+
 
 private:
     Syscalls();

--- a/nre/include/Syscalls.h
+++ b/nre/include/Syscalls.h
@@ -272,7 +272,7 @@ public:
      * @param op the requested operation
      * @throws SyscallException if the system-call failed (result != E_SUCCESS)
      */
-    static void vi_ctrl(capsel_t vi, ViOp op, word_t mask = ~0UL) {
+    static void vi_ctrl(capsel_t vi, ViOp op, word_t mask) {
         SyscallABI::syscall(vi << 8 | VI_CTRL | op, mask);
     }
 

--- a/nre/include/Syscalls.h
+++ b/nre/include/Syscalls.h
@@ -272,8 +272,8 @@ public:
      * @param op the requested operation
      * @throws SyscallException if the system-call failed (result != E_SUCCESS)
      */
-    static void vi_ctrl(capsel_t vi, ViOp op) {
-        SyscallABI::syscall(vi << 8 | VI_CTRL | op);
+    static void vi_ctrl(capsel_t vi, ViOp op, word_t mask = ~0UL) {
+        SyscallABI::syscall(vi << 8 | VI_CTRL | op, mask);
     }
 
 

--- a/nre/include/kobj/Mutex.h
+++ b/nre/include/kobj/Mutex.h
@@ -51,7 +51,15 @@ namespace nre {
             // can be NULL already, if someone woke us up between the
             // cmpnswap and here.
 
-            if (newv) current->mutex_wait();
+            if (newv) {
+#ifndef NDEBUG
+                for (Thread *cur = current->_waiting_for; cur;
+                     cur = cur->_waiting_for) {
+                    assert(cur != current /* deadlock */);
+                }
+#endif
+                current->mutex_wait();
+            }
 
             assert (current->_waiting_for == NULL);
             assert (current->fetch_events(1) == 0);

--- a/nre/include/kobj/Mutex.h
+++ b/nre/include/kobj/Mutex.h
@@ -1,0 +1,90 @@
+/* -*- Mode: C++ -*-
+ * Copyright (C) 2012, Julian Stecklina <jsteckli@os.inf.tu-dresden.de>
+ * Economic rights: Technische Universitaet Dresden (Germany)
+ *
+ * This file is part of NRE (NOVA runtime environment).
+ *
+ * NRE is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * NRE is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License version 2 for more details.
+ */
+
+#pragma once
+
+#include <kobj/Vi.h>
+#include <util/Atomic.h>
+#include <kobj/Thread.h>
+
+namespace nre {
+
+    class Mutex {
+    private:
+        Thread           *_lock_holder;   // Only for debugging.
+        Thread * volatile _wait_list;
+
+    public:
+        Mutex() : _lock_holder(nullptr), _wait_list(nullptr) { }
+
+        void acquire()
+        {
+            Thread *current = Thread::current();
+            assert(not current->_waiting_for);
+            assert(current->fetch_events(1) == 0);
+
+            current->ensure_mutex_irq();
+            
+            do
+                current->_waiting_for = _wait_list;
+            while (not Atomic::cmpnswap(&_wait_list,
+                                        current->_waiting_for, current));
+
+            // We are in the wait list. If we are the tail of the
+            // list, we are in the critical section. Otherwise, we
+            // must wait.
+
+            if (current->_waiting_for) current->mutex_wait();
+
+            _lock_holder = current;
+            Sync::memory_barrier();
+        }
+
+        void release()
+        {
+            Thread *current = Thread::current();
+            assert (_lock_holder == current);
+            assert (_wait_list);
+
+            // The hopefully common case: The mutex is uncontended.
+            while (_wait_list == current) {
+                if (Atomic::cmpnswap(&_wait_list, current, (Thread *)nullptr))
+                    // Successfull release. Nobody to wake up.
+                    return;
+                // XXX Actually, this will never loop. Because after
+                // cmpnswap fails, the loop condition will be false.
+            }
+
+            // It does not matter, if someone enqueues himself at the
+            // front of the list at this point.
+            Thread *head = _wait_list;
+
+            // XXX The t->next non-NULL test can be removed, if we are
+            // sure this is working properly.
+            for (; head->_waiting_for and (head->_waiting_for != current); head = head->_waiting_for) { }
+            assert (head->_waiting_for == current);
+
+            // No worries about atomic ops here, because the mutex
+            // protects the dequeue operation.
+            head->_waiting_for = nullptr;
+            head->mutex_wakeup();
+        }
+
+    };
+
+}
+
+// EOF

--- a/nre/include/kobj/ObjCap.h
+++ b/nre/include/kobj/ObjCap.h
@@ -79,7 +79,7 @@ protected:
     }
 
 private:
-    // object-caps are non-copyable, because I think there are very few usecases and often it
+    // object-caps cannot be copied, because I think there are very few usecases and often it
     // causes problems:
     // - how to clone a Sm? we can't clone the current state of it, i.e. its value. so it would be
     //   a partial clone, which is strange.

--- a/nre/include/kobj/Thread.h
+++ b/nre/include/kobj/Thread.h
@@ -105,6 +105,13 @@ public:
     }
 
     /**
+     * Fetch the current event bit mask and atomically set it to zero.
+     *
+     * @return event bit mask
+     */
+    word_t fetch_events() { return utcb()->fetch_events(); }
+
+    /**
      * Creates a new TLS slot for all Threads
      *
      * @return the TLS index

--- a/nre/include/kobj/Vi.h
+++ b/nre/include/kobj/Vi.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2012, Julian Stecklina <jsteckli@os.inf.tu-dresden.de>
+ * Economic rights: Technische Universitaet Dresden (Germany)
+ *
+ * This file is part of NRE (NOVA runtime environment).
+ *
+ * NRE is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * NRE is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License version 2 for more details.
+ */
+
+#pragma once
+
+#include <kobj/ObjCap.h>
+#include <kobj/Pd.h>
+#include <arch/SyscallABI.h>
+
+namespace nre {
+
+    class Vi : public ObjCap {
+    public:
+        explicit Vi(capsel_t cap) : ObjCap(cap, KEEP_CAP_BIT | KEEP_SEL_BIT) { }
+
+        explicit Vi(Thread *ec_handler, Thread *ec_recall, capsel_t cap, uint32_t evt, Pd *pd = Pd::current())
+            : ObjCap(cap, KEEP_SEL_BIT)
+        {
+            Syscalls::create_vi(cap, ec_handler->sel(), ec_recall->sel(), evt, pd->sel());
+        }
+
+
+        static void block()   { Syscalls::vi_ctrl(0,     Syscalls::ViOp::BLOCK);   }
+               void trigger() { Syscalls::vi_ctrl(sel(), Syscalls::ViOp::TRIGGER); }
+    };
+
+}

--- a/nre/include/utcb/UtcbBase.h
+++ b/nre/include/utcb/UtcbBase.h
@@ -62,11 +62,13 @@ public:
     }
 
     /**
-     * Fetch the current event bit mask and atomically set it to zero.
+     * Fetch the current event bit mask and atomically set it to
+     * zero. Respects the given mask, i.e. only those bits set in the
+     * mask are cleared and returned.
      *
-     * @return event bit mask
+     * @return event bitmask
      */
-    word_t fetch_events() { return Atomic::xchg(events, (word_t)0); }
+    word_t fetch_events(word_t mask = ~0UL) { return mask & __sync_fetch_and_and(&events, ~mask); }
 };
 
 }

--- a/nre/include/utcb/UtcbBase.h
+++ b/nre/include/utcb/UtcbBase.h
@@ -18,6 +18,7 @@
 
 #include <arch/ExecEnv.h>
 #include <utcb/UtcbHead.h>
+#include <util/Atomic.h>
 
 namespace nre {
 
@@ -59,6 +60,13 @@ public:
         crd = 0;
         crd_translate = 0;
     }
+
+    /**
+     * Fetch the current event bit mask and atomically set it to zero.
+     *
+     * @return event bit mask
+     */
+    word_t fetch_events() { return Atomic::xchg(events, (word_t)0); }
 };
 
 }

--- a/nre/include/utcb/UtcbHead.h
+++ b/nre/include/utcb/UtcbHead.h
@@ -60,7 +60,7 @@ protected:
     };
     word_t crd_translate;
     word_t crd;
-    word_t reserved;
+    word_t events;
 };
 
 }

--- a/nre/include/util/Atomic.h
+++ b/nre/include/util/Atomic.h
@@ -107,6 +107,13 @@ public:
     }
 #endif
 
+
+    template <typename T>
+    static T xchg(T &v, T newv)
+    {
+        return __sync_lock_test_and_set(&v, newv);
+    }
+
 private:
     Atomic();
 };

--- a/nre/libs/libstdc++/kobj/Vi.cc
+++ b/nre/libs/libstdc++/kobj/Vi.cc
@@ -1,4 +1,4 @@
-/*  -*- Mode: C++ -*-
+/*
  * Copyright (C) 2012, Julian Stecklina <jsteckli@os.inf.tu-dresden.de>
  * Economic rights: Technische Universitaet Dresden (Germany)
  *
@@ -14,24 +14,16 @@
  * General Public License version 2 for more details.
  */
 
-#pragma once
-
-#include <kobj/ObjCap.h>
-#include <kobj/Pd.h>
-#include <arch/SyscallABI.h>
+#include <kobj/Vi.h>
+#include <kobj/Thread.h>
 
 namespace nre {
 
-    class Thread;
-
-    class Vi : public ObjCap {
-    public:
-        explicit Vi(capsel_t cap) : ObjCap(cap, KEEP_CAP_BIT | KEEP_SEL_BIT) { }
-        explicit Vi(Thread *ec_handler, Thread *ec_recall, capsel_t cap, uint32_t evt, Pd *pd = Pd::current());
-
-        static void block(word_t mask = ~0UL) { Syscalls::vi_ctrl(0, Syscalls::ViOp::BLOCK, mask); }
-        void trigger() { Syscalls::vi_ctrl(sel(), Syscalls::ViOp::TRIGGER, 0); }
-    };
+Vi::Vi(Thread *ec_handler, Thread *ec_recall, capsel_t cap, uint32_t evt, Pd *pd)
+    : ObjCap(cap, KEEP_SEL_BIT)
+{
+    Syscalls::create_vi(cap, ec_handler->sel(), ec_recall ? ec_recall->sel() : 0, evt, pd->sel());
+}
 
 }
 

--- a/nre/libs/libstdc++/stream/OStream.cc
+++ b/nre/libs/libstdc++/stream/OStream.cc
@@ -286,11 +286,10 @@ void OStream::printptr(uintptr_t u, uint flags) {
     size_t size = sizeof(uintptr_t);
     flags |= PADZEROS;
     // 2 hex-digits per byte and a ':' every 2 bytes
+    if (size > 2) { write('0'); write('x'); }
     while(size > 0) {
         printupad((u >> (size * 8 - 16)) & 0xFFFF, 16, 4, flags);
         size -= 2;
-        if(size > 0)
-            write(':');
     }
 }
 


### PR DESCRIPTION
**Disclaimer: This is only meant as discussion and is not ready to be merged.**

I have implemented virtual IRQs for NOVA. The implementation is influenced by Fiasco.OC's virtual IRQs, but differs in some important ways. The goal is to have a simple event notification system in the kernel that supersedes kernel semaphores and simplifies vancouver.

Comments are welcome.
### New kernel mechanisms

Let me outline what the implementation currently provides: On creation time vIRQs are bound to one EC (the handler), which can wait (block) for events on all virtual IRQs that are connected to it.

vIRQ objects can be freely delegated and the only operation on them is to trigger them. Events are distinguished by sticking an event bitmask to each vIRQ object (also on creation time). If the vIRQ is triggered, this bitmask is OR-ed into the handling EC's UTCB. I repurposed utcb.tls (now named utcb.event), because no one uses it.

ECs can voluntarily block to wait for events. If events are pending, ECs will wakeup (or not block at all). The handling EC is then responsible to zero the relevant bits in its event bit mask in its UTCB. The block operation takes an additional mask parameter to limit wakeups to specific events.

There is also experimental support for adding another EC to the virtual IRQ that gets recalled whenever the handler EC is not actively blocking. Those two ECs may be the same or not. This feature is useful to implement asynchronous timeouts or events in Vancouver that need to be handled in VCPU context. This removes one kernel entry and context switch in Vancouver's usual IRQ injection path.

The code is in my NOVA repository in the virq branch. The syscall interface is not very beautiful at the moment and there is minor code duplication with the semaphore implementation, but the current goal is to make tracking upstream NOVA feasible for me.
### New userspace mechanisms

I implemented a userspace mutex built on top of virtual IRQs. It survives stress testing and may be used in all places where NRE currently uses userspace semaphores. I will try out the latter in the coming days and see what happens.

The implementation is in [include/kobj/Mutex.h](https://github.com/blitz/NRE/blob/virq/nre/include/kobj/Mutex.h).
### Pros/Cons

Pro:
- Threads can wait on an arbitrary number of events. Events are merged and threads will see them all at once, but still can distinguish what happened (if they want to)
- Mutexes are implemented in userland:
  - cheap deadlock detection!
  - easy to debug who waits for whom
- ...

Contra:
- you can get half the way with the current semaphore implementation
- you lose the ability for using kernel semaphores for cross-PD critical sections
  - but no one uses it anyway!
- ...
