### PR TITLE
Add kernelbuild benchmark

### DIFF
--- a/nre/boot/vancouver-kernelbuild.wv
+++ b/nre/boot/vancouver-kernelbuild.wv
@@ -1,0 +1,17 @@
+#!tools/novaboot
+# -*-sh-*-
+QEMU_FLAGS=-m 1500 -smp 4
+HYPERVISOR_PARAMS=serial
+bin/apps/root
+bin/apps/acpi provides=acpi
+bin/apps/keyboard provides=keyboard
+bin/apps/reboot provides=reboot
+bin/apps/pcicfg provides=pcicfg
+bin/apps/timer provides=timer
+bin/apps/console provides=console
+bin/apps/sysinfo
+bin/apps/storage provides=storage
+bin/apps/vancouver mods=following lastmod m:950 ncpu:1 PC_PS2
+bin/apps/guest_munich
+dist/imgs/bzImage-3.1.0-32 clocksource=tsc console=ttyS0 noapic quiet
+dist/imgs/kernelbuild-e2fs.bz2


### PR DESCRIPTION
with this benchmark, it is possible to compare the performance of NRE and
NUL. The needed dist/imgs/kernelbuild-e2fs.bz2 can be taken from NUL imgs
repo. On my Ivy Bridge box the results are as follows:

NUL x86_32: 485 s
NRE x86_64: 484 s
NRE x86_32: 484 s (vancouver was run with only 900M of mem, 950M failed)
